### PR TITLE
Prefix with so number in version string

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,22 +1,24 @@
-{% set year = '2018' %}
-{% set version = year + '0712' %}
-{% set next_year = year|int + 1 %}
-{% set sha256 = "2dfaa34feb7d6dc833ce0f3d0504b31ed409f218d0d8e43c389bb050f0081ff2" %}
+{% set so_number = '152' %}
+{% set epoch = '1' %}
+{% set version_prefix = epoch + '!' + so_number %}
+{% set release_date = '20180717' %}
+{% set version = version_prefix + '.' + release_date %}
+{% set sha256 = "e991cad3cc656d683edacaccffc0352a7b5d4dd123ae43aebfe37c9cc52548bd" %}
 
 package:
   name: x264
   version: {{ version }}
 
 source:
-  fn: x264-snapshot-{{ version }}-2245-stable.tar.bz2
-  url: http://download.videolan.org/pub/videolan/x264/snapshots/x264-snapshot-{{ version }}-2245-stable.tar.bz2
+  fn: x264-snapshot-{{ release_date }}-2245-stable.tar.bz2
+  url: http://download.videolan.org/pub/videolan/x264/snapshots/x264-snapshot-{{ release_date }}-2245-stable.tar.bz2
   sha256: {{ sha256 }}
 
 build:
   number: 0
   skip: true         # [win]
   run_exports:
-    - x264 >={{ version }},<{{ next_year }}0000
+    - x264 >={{ version }},<{{ epoch + '!' }}{{ so_number|int + 1 }}
 
 requirements:
   build:
@@ -27,11 +29,13 @@ requirements:
 
 test:
   commands:
-    - test -f ${PREFIX}/include/x264.h         # [unix]
-    - test -f ${PREFIX}/lib/libx264.a          # [unix]
-    - test -f ${PREFIX}/lib/libx264.dylib      # [osx]
-    - test -f ${PREFIX}/lib/libx264.so         # [linux]
-    - x264 --help                              # [unix]
+    - test -f ${PREFIX}/include/x264.h                     # [unix]
+    - test -f ${PREFIX}/lib/libx264.a                      # [unix]
+    - test -f ${PREFIX}/lib/libx264.dylib                  # [osx]
+    - test -f ${PREFIX}/lib/libx264.{{ so_number }}.dylib  # [osx]
+    - test -f ${PREFIX}/lib/libx264.so                     # [linux]
+    - test -f ${PREFIX}/lib/libx264.so.{{ so_number }}     # [linux]
+    - x264 --help                                          # [unix]
 
 about:
   home: http://www.videolan.org/developers/x264.html
@@ -44,3 +48,4 @@ extra:
     - jakirkham
     - 183amir
     - carlodri
+    - sdvillal


### PR DESCRIPTION
Proposes a new version string: ```soname.release_date```. Updates run_exports accordingly.

Checklist
* [X] Used a fork of the feedstock to propose changes
* [X] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`

