### PR TITLE
Split into CLI and LIB packages, use soname in lib package version

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Current release info
 
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-libx264-green.svg)](https://anaconda.org/conda-forge/libx264) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libx264.svg)](https://anaconda.org/conda-forge/libx264) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libx264.svg)](https://anaconda.org/conda-forge/libx264) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libx264.svg)](https://anaconda.org/conda-forge/libx264) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-x264-green.svg)](https://anaconda.org/conda-forge/x264) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/x264.svg)](https://anaconda.org/conda-forge/x264) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/x264.svg)](https://anaconda.org/conda-forge/x264) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/x264.svg)](https://anaconda.org/conda-forge/x264) |
 
 Installing x264
@@ -34,16 +35,16 @@ Installing `x264` from the `conda-forge` channel can be achieved by adding `cond
 conda config --add channels conda-forge
 ```
 
-Once the `conda-forge` channel has been enabled, `x264` can be installed with:
+Once the `conda-forge` channel has been enabled, `libx264, x264` can be installed with:
 
 ```
-conda install x264
+conda install libx264 x264
 ```
 
-It is possible to list all of the versions of `x264` available on your platform with:
+It is possible to list all of the versions of `libx264` available on your platform with:
 
 ```
-conda search x264 --channel conda-forge
+conda search libx264 --channel conda-forge
 ```
 
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,6 +10,7 @@ else
 fi
 export CFLAGS
 export CXXLAGS="${CFLAGS}"
+export AS=`which nasm`
 
 chmod +x configure
 ./configure \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,22 +1,20 @@
-{% set year = '2018' %}
-{% set version = year + '0712' %}
-{% set next_year = year|int + 1 %}
-{% set sha256 = "2dfaa34feb7d6dc833ce0f3d0504b31ed409f218d0d8e43c389bb050f0081ff2" %}
+{% set so_number = '152' %}
+{% set release_date = '20180713' %}
+{% set lib_version = so_number + '.' + release_date %}
+{% set sha256 = "9796a1a022ff3cb8e54df3322b645b2aca5a4c19524d0da6404ea731627e719b" %}
 
 package:
   name: x264
-  version: {{ version }}
+  version: {{ release_date }}
 
 source:
-  fn: x264-snapshot-{{ version }}-2245-stable.tar.bz2
-  url: http://download.videolan.org/pub/videolan/x264/snapshots/x264-snapshot-{{ version }}-2245-stable.tar.bz2
+  fn: x264-snapshot-{{ release_date }}-2245-stable.tar.bz2
+  url: http://download.videolan.org/pub/videolan/x264/snapshots/x264-snapshot-{{ release_date }}-2245-stable.tar.bz2
   sha256: {{ sha256 }}
 
 build:
   number: 0
   skip: true         # [win]
-  run_exports:
-    - x264 >={{ version }},<{{ next_year }}0000
 
 requirements:
   build:
@@ -25,13 +23,40 @@ requirements:
   host:
     - nasm
 
+# This is here just to fool the linter until
+#  https://github.com/conda-forge/conda-smithy/issues/833
+# is fixed
 test:
   commands:
-    - test -f ${PREFIX}/include/x264.h         # [unix]
-    - test -f ${PREFIX}/lib/libx264.a          # [unix]
-    - test -f ${PREFIX}/lib/libx264.dylib      # [osx]
-    - test -f ${PREFIX}/lib/libx264.so         # [linux]
-    - x264 --help                              # [unix]
+
+outputs:
+  - name: x264
+    build:
+      run_exports:
+         - {{ pin_subpackage('libx264') }}
+    files:
+      - bin/x264
+    test:
+      commands:
+        - x264 --help                                          # [unix]
+
+  - name: libx264
+    version: {{ lib_version }}
+    build:
+      run_exports:
+        - libx264 >={{ so_number }}.00000000,<{{ so_number|int + 1 }}.00000000
+    files:
+      - include/x264*
+      - lib/libx264*
+      - lib/pkgconfig/x264.pc
+    test:
+      commands:
+        - test -f ${PREFIX}/include/x264.h                     # [unix]
+        - test -f ${PREFIX}/lib/libx264.a                      # [unix]
+        - test -f ${PREFIX}/lib/libx264.dylib                  # [osx]
+        - test -f ${PREFIX}/lib/libx264.{{ so_number }}.dylib  # [osx]
+        - test -f ${PREFIX}/lib/libx264.so                     # [linux]
+        - test -f ${PREFIX}/lib/libx264.so.{{ so_number }}     # [linux]
 
 about:
   home: http://www.videolan.org/developers/x264.html
@@ -44,3 +69,4 @@ extra:
     - jakirkham
     - 183amir
     - carlodri
+    - sdvillal

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,7 @@ outputs:
     version: {{ lib_version }}
     build:
       run_exports:
-        - libx264 >={{ so_number }}.00000000,<{{ so_number|int + 1 }}.00000000
+        - {{ pin_subpackage('libx264') }}
     files:
       - include/x264*
       - lib/libx264*


### PR DESCRIPTION
Alternative to #18.

@183amir @isuruf I would be happy if you can review.

- Is this what you have in mind @isuruf?
- I do not like how we need to hardcode the file paths. Any alternative?
- I do not know if I got right run_exports.
- I think downstream dependencies most likely want to depend on libx264 (that is the logical thing to do). I will add a second commit trying to go that path.

I will try to carry the same tests I did for #18, namely that pins are respected downstream.